### PR TITLE
restructure eval_driver code

### DIFF
--- a/bankofanthos_prototype/eval_driver/diff/diff.go
+++ b/bankofanthos_prototype/eval_driver/diff/diff.go
@@ -1,7 +1,8 @@
-package main
+package diff
 
 import (
 	"bankofanthos_prototype/eval_driver/pb"
+	"bankofanthos_prototype/eval_driver/service"
 	"fmt"
 	"os"
 	"strconv"
@@ -13,8 +14,11 @@ import (
 )
 
 var (
-	fromFile = "baseline"
-	toFile   = "comparison"
+	fromFile              = "baseline"
+	toFile                = "comparison"
+	nonDeterministicField = "nondeterministic/"
+	databaseType          = "database"
+	responseType          = "response"
 )
 
 // checkLine checks each row to find non-deterministic column
@@ -47,7 +51,7 @@ func checkLine(baseline, experimental []string, idx int) ([]*pb.RowInfo, error) 
 }
 
 // getDiffHelper parses diff result in protobuf format
-func getDiffHelper(result string, compareType string) (*pb.DiffInfos, error) {
+func getDiffHelper(result string) (*pb.DiffInfos, error) {
 	diffInfos := &pb.DiffInfos{}
 	diffLines := strings.Split(result, "\n")
 	for i := 0; i < len(diffLines); i++ {
@@ -130,7 +134,7 @@ func getNonDeterministicInfo(path1, path2 string, compareType string) error {
 	}
 
 	// parse the result, get the lines and columns for the non-deterministic field
-	diffInfos, err := getDiffHelper(result, compareType)
+	diffInfos, err := getDiffHelper(result)
 	if err != nil {
 		return err
 	}
@@ -155,15 +159,15 @@ func getNonDeterministicInfo(path1, path2 string, compareType string) error {
 	return nil
 }
 
-func getNonDeterministic(baselineService1, baselineService2 Service) error {
+func GetNonDeterministic(baselineService1, baselineService2 service.Service) error {
 	// get database diff
-	err := getNonDeterministicInfo(baselineService1.dumpDbPath, baselineService2.dumpDbPath, databaseType)
+	err := getNonDeterministicInfo(baselineService1.DumpDbPath, baselineService2.DumpDbPath, databaseType)
 	if err != nil {
 		return err
 	}
 
 	// get response diff
-	err = getNonDeterministicInfo(baselineService1.outputPath, baselineService2.outputPath, responseType)
+	err = getNonDeterministicInfo(baselineService1.OutputPath, baselineService2.OutputPath, responseType)
 	if err != nil {
 		return err
 	}
@@ -173,7 +177,7 @@ func getNonDeterministic(baselineService1, baselineService2 Service) error {
 
 // outputEq compares two files content, print out the diff and return
 // a equal bool.
-func outputEq(path1 string, path2 string, compareType string) (bool, error) {
+func OutputEq(path1 string, path2 string, compareType string) (bool, error) {
 	output1, err := os.ReadFile(path1)
 	if err != nil {
 		return false, err
@@ -211,7 +215,7 @@ func outputEq(path1 string, path2 string, compareType string) (bool, error) {
 		return true, nil
 	}
 
-	experimentalDiff, err := getDiffHelper(result, compareType)
+	experimentalDiff, err := getDiffHelper(result)
 	if err != nil {
 		return false, err
 	}

--- a/bankofanthos_prototype/eval_driver/diff/diff_test.go
+++ b/bankofanthos_prototype/eval_driver/diff/diff_test.go
@@ -1,4 +1,4 @@
-package main
+package diff
 
 import (
 	"bankofanthos_prototype/eval_driver/pb"
@@ -63,7 +63,7 @@ func TestGetDiffHelper(t *testing.T) {
 		},
 	}
 
-	diffInfos, err := getDiffHelper(diff, "database")
+	diffInfos, err := getDiffHelper(diff)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/bankofanthos_prototype/eval_driver/service/database.go
+++ b/bankofanthos_prototype/eval_driver/service/database.go
@@ -1,4 +1,4 @@
-package main
+package service
 
 import (
 	"bankofanthos_prototype/eval_driver/dbclone"
@@ -11,8 +11,8 @@ import (
 )
 
 type database struct {
-	branch string
-	port   string
+	Branch string
+	Port   string
 }
 
 func getDatabaseByBranchName(branchName string) (database, error) {
@@ -51,14 +51,14 @@ func getDatabaseByBranchName(branchName string) (database, error) {
 		return database, nil
 	}
 
-	database.port = strings.Split(address, ":")[1]
-	database.branch = branchName
+	database.Port = strings.Split(address, ":")[1]
+	database.Branch = branchName
 
 	return database, nil
 }
 
 // cloneDatabase clones a database from ancestorBranchName if it does not exist.
-func cloneNeonDatabase(branchName, ancestorBranchName string, switchCloning bool) (database, error) {
+func CloneNeonDatabase(branchName, ancestorBranchName string, switchCloning bool) (database, error) {
 	db := database{}
 
 	// running database fork command under neon directory
@@ -87,7 +87,7 @@ func cloneNeonDatabase(branchName, ancestorBranchName string, switchCloning bool
 	if err != nil {
 		return db, nil
 	}
-	if existingDb.branch == branchName && existingDb.port != "" {
+	if existingDb.Branch == branchName && existingDb.Port != "" {
 		return existingDb, nil
 	}
 
@@ -124,7 +124,7 @@ func cloneNeonDatabase(branchName, ancestorBranchName string, switchCloning bool
 			fmt.Printf("Error changing back to original directory: %v\n", err)
 			return db, err
 		}
-		err = switchRPlusRMinusCloning(db.port)
+		err = switchRPlusRMinusCloning(db.Port)
 		return db, err
 	}
 

--- a/bankofanthos_prototype/eval_driver/service/requests.go
+++ b/bankofanthos_prototype/eval_driver/service/requests.go
@@ -1,4 +1,4 @@
-package main
+package service
 
 import (
 	"fmt"
@@ -165,9 +165,9 @@ func sendReq(client http.Client, port string, send sendStruct) (string, error) {
 	return bodyString, nil
 }
 
-type listOfReqs func() []interface{}
+type ListOfReqs func() []interface{}
 
-func listOfReqs1() []interface{} {
+func ListOfReqs1() []interface{} {
 	args := []interface{}{}
 	username := "test"
 	password := "1234"


### PR DESCRIPTION
Pure refactoring, reorganize folder structure to

```
├── eval_driver
│   ├── dbclone
|   |   ├── ... 
│   ├── diff
|   │   ├── diff.go
|   |   ├── ...
│   ├── service
│   ├── main.go
```

 This pr only reorganize folder structure. It does not refactor code.