### PR TITLE
Modify diff printing

### DIFF
--- a/bankofanthos_prototype/eval_driver/diff/formatter_test.go
+++ b/bankofanthos_prototype/eval_driver/diff/formatter_test.go
@@ -74,27 +74,27 @@ func TestInlineDiffFormat(t *testing.T) {
 ├───┼────┼─────────────────┼──────┤
 │ = │ 0  │ UNERA9rI2cvTK4U │ A    │
 │ < │ 0  │ UNERA9rI2cvTK4U │ A    │
-│ > │    │                 │      │
+│ > │ -  │ -               │ -    │
 ├───┼────┼─────────────────┼──────┤
 │ = │ 1  │ pL              │ BB   │
 │ < │ 1  │ pL              │ BB   │
 │ > │ 1  │ pL              │ B    │
 ├───┼────┼─────────────────┼──────┤
 │ = │ 2  │ SiOW4eQ         │ C    │
-│ < │    │                 │      │
+│ < │ -  │ -               │ -    │
 │ > │ 2  │ SiOW4eQ         │ C    │
 ├───┼────┼─────────────────┼──────┤
 │ = │ 3  │ jKsRdMxCv       │ D    │
-│ < │    │                 │      │
-│ > │    │                 │      │
+│ < │ -  │ -               │ -    │
+│ > │ -  │ -               │ -    │
 ├───┼────┼─────────────────┼──────┤
-│ = │    │                 │      │
+│ = │ -  │ -               │ -    │
 │ < │ 4  │ gltBHYVJQV      │ E    │
 │ > │ 4  │ orCMYJxL8       │ E    │
 ├───┼────┼─────────────────┼──────┤
 │ = │ 5  │ gvMTIQB         │ F    │
 │ < │ 5  │ gvMTIQB         │ FFFF │
-│ > │    │                 │      │
+│ > │ -  │ -               │ -    │
 ╰───┴────┴─────────────────┴──────╯
 `
 	if diff := cmp.Diff(expectedString[1:], plainText); diff != "" {
@@ -111,13 +111,14 @@ func TestSideBySideDiffFormat(t *testing.T) {
 
 	expectedString := `
 USER
- ID  PASSWORD         NAME | ID  PASSWORD         NAME | ID  PASSWORD         NAME 
- 0   UNERA9rI2cvTK4U  A    | 0   UNERA9rI2cvTK4U  A    |                           
- 1   pL               BB   | 1   pL               BB   | 1   pL               B    
-                           | 2   SiOW4eQ          C    | 2   SiOW4eQ          C    
-                           | 3   jKsRdMxCv        D    |                           
- 4   gltBHYVJQV       E    |                           | 4   orCMYJxL8        E    
- 5   gvMTIQB          FFFF | 5   gvMTIQB          F    |                           
+ <                         │ =                         │ >                         
+ ID  PASSWORD         NAME │ ID  PASSWORD         NAME │ ID  PASSWORD         NAME 
+ 0   UNERA9rI2cvTK4U  A    │ 0   UNERA9rI2cvTK4U  A    │ -   -                -    
+ 1   pL               BB   │ 1   pL               BB   │ 1   pL               B    
+ -   -                -    │ 2   SiOW4eQ          C    │ 2   SiOW4eQ          C    
+ -   -                -    │ 3   jKsRdMxCv        D    │ -   -                -    
+ 4   gltBHYVJQV       E    │ -   -                -    │ 4   orCMYJxL8        E    
+ 5   gvMTIQB          FFFF │ 5   gvMTIQB          F    │ -   -                -    
 `
 
 	plainText := removeColorCodes(output)

--- a/bankofanthos_prototype/eval_driver/diff/inline_diff.go
+++ b/bankofanthos_prototype/eval_driver/diff/inline_diff.go
@@ -102,6 +102,8 @@ func (i *inlineFormatter) format() error {
 					a.S = prefix[p]
 				} else if len(text) > 0 {
 					a = text[j-1]
+				} else {
+					a = atom{S: "-", Color: "", Bold: true}
 				}
 				s := a.String()
 				return fmt.Sprintf(" %-*s ", w-len(a.S)+len(s), a)

--- a/bankofanthos_prototype/eval_driver/diff/side_by_side_diff.go
+++ b/bankofanthos_prototype/eval_driver/diff/side_by_side_diff.go
@@ -53,8 +53,30 @@ func (s *sideBySideDiffFormatter) format() error {
 	fmt.Fprintln(s.w, strings.ToUpper(s.tableName))
 
 	// col names
+	writeRow("│", func(j, w int) string {
+		s := strings.ToUpper(controlPrefix)
+		if j != 0 {
+			s = ""
+		}
+		return fmt.Sprintf(" %-*s ", w, s)
+	})
+	writeRow("│", func(j, w int) string {
+		s := strings.ToUpper(baselinePrefix)
+		if j != 0 {
+			s = ""
+		}
+		return fmt.Sprintf(" %-*s ", w, s)
+	})
+	writeRow("\n", func(j, w int) string {
+		s := strings.ToUpper(experimentalPrefix)
+		if j != 0 {
+			s = ""
+		}
+		return fmt.Sprintf(" %-*s ", w, s)
+	})
+
 	for i := 0; i < 3; i++ {
-		end := "|"
+		end := "│"
 		if i == 2 {
 			end = "\n"
 		}
@@ -70,14 +92,16 @@ func (s *sideBySideDiffFormatter) format() error {
 
 		texts := [][]atom{s.control[r], s.baseline[r], s.experimental[r]}
 		for i, text := range texts {
-			end := "|"
+			end := "│"
 			if i == 2 {
 				end = "\n"
 			}
 			writeRow(end, func(j, w int) string {
-				a := atom{}
+				var a atom
 				if len(text) > 0 {
 					a = text[j]
+				} else {
+					a = atom{S: "-", Color: "", Bold: true}
 				}
 				s := a.String()
 				return fmt.Sprintf(" %-*s ", w-len(a.S)+len(s), a)


### PR DESCRIPTION
- Add `-` for missing column
- Change vertical bars to unicode box drawing characters
- Add prefix on top of side-by-side diff.

![Screenshot from 2024-04-09 14-20-43](https://github.com/ServiceWeaver/database/assets/27516052/21aa47a1-4a78-4ead-b4da-97db6df15518)
